### PR TITLE
Fix implicit function declarations (for C99 compatibility)

### DIFF
--- a/src/async.c
+++ b/src/async.c
@@ -130,8 +130,8 @@ async_is_transferring ()
   return gIsTransferring;
 }
 
-int
-async_sftp_transfer (gpointer userdata)
+void *
+async_sftp_transfer (void *userdata)
 {
   int i, rc;
   int nUp, nDown;

--- a/src/async.h
+++ b/src/async.h
@@ -15,7 +15,7 @@ void asyncInit();
 gpointer async_lterm_loop(gpointer data);
 
 gboolean async_is_transferring ();
-int async_sftp_transfer (gpointer userdata);
+void *async_sftp_transfer (void *userdata);
 
 void lockSSH (char *caller, gboolean flagLock);
 

--- a/src/async.h
+++ b/src/async.h
@@ -17,5 +17,6 @@ gpointer async_lterm_loop(gpointer data);
 gboolean async_is_transferring ();
 int async_sftp_transfer (gpointer userdata);
 
-#endif
+void lockSSH (char *caller, gboolean flagLock);
 
+#endif

--- a/src/connection.c
+++ b/src/connection.c
@@ -1528,7 +1528,7 @@ add_update_connection (struct GroupNode *p_node, struct Connection *p_conn_model
   if (gtk_builder_add_from_file (builder, ui, &error) == 0)
     {
       msgbox_error ("Can't load user interface file:\n%s", error->message);
-      return;
+      return NULL;
     }
     
   log_debug ("Loaded %s\n", ui);

--- a/src/connection.c
+++ b/src/connection.c
@@ -1373,7 +1373,7 @@ select_private_key_cb (GtkButton *button, gpointer user_data)
   
   if (result == GTK_RESPONSE_ACCEPT)
     {
-      gtk_entry_set_text (authWidgets.entry_private_key, gtk_file_chooser_get_filename (GTK_FILE_CHOOSER(dialog)));
+      gtk_entry_set_text (GTK_ENTRY (authWidgets.entry_private_key), gtk_file_chooser_get_filename (GTK_FILE_CHOOSER(dialog)));
     }
     
   gtk_widget_destroy (dialog);
@@ -1382,7 +1382,7 @@ select_private_key_cb (GtkButton *button, gpointer user_data)
 void
 clear_private_key_cb (GtkButton *button, gpointer user_data)
 {
-  gtk_entry_set_text (authWidgets.entry_private_key, "");
+  gtk_entry_set_text (GTK_ENTRY (authWidgets.entry_private_key), "");
 }
 
 void

--- a/src/connection.c
+++ b/src/connection.c
@@ -37,6 +37,7 @@
 #include "main.h"
 #include "utils.h"
 #include "xml.h"
+#include "terminal.h"
 
 #define SEARCH_BY_NAME "Search by name"
 #define SEARCH_BY_HOST "Search by host"
@@ -94,6 +95,8 @@ int rows_signals_enabled = 1;
 int g_rebuilding_tree_store = 0;
 
 GtkWidget * create_connections_tree_view ();
+
+static int get_selected_connection (GtkTreeSelection *, struct Connection *);
 
 void
 connection_init_stuff ()
@@ -1116,7 +1119,7 @@ load_connections ()
 }
 
 int
-count_current_connections ()
+count_current_connections (void)
 {
   return (cl_count (&conn_list));
 }
@@ -2769,7 +2772,7 @@ create_search_by_combo ()
   return (search_by_combo);
 }
 
-int
+static int
 get_selected_connection (GtkTreeSelection *select, struct Connection *p_conn)
 {
   GtkTreeIter iter;

--- a/src/connection.h
+++ b/src/connection.h
@@ -54,6 +54,12 @@ void connection_init_stuff ();
 void rebuild_tree_store ();
 GtkWidget *create_entry_control (char *label, GtkWidget *entry);
 void create_quick_launch_window (struct QuickLaunchWindow *p_qlv);
+int conn_update_last_user (char *cname, char *last_user);
+int choose_manage_connection (struct Connection *p_conn);
+int count_current_connections (void);
+int save_connections_to_file_xml (char *filename);
+
+void refresh_connection_tree_view (GtkTreeView *tree_view);
 
 #endif
 

--- a/src/connection_list.h
+++ b/src/connection_list.h
@@ -97,6 +97,9 @@ struct Connection *cl_insert_sorted (struct Connection_List *p_cl, struct Connec
 struct Connection *cl_host_search (struct Connection_List *p_cl, char *host, char *skip_this);
 struct Connection *cl_get_by_index (struct Connection_List *p_cl, int index);
 struct Connection *cl_get_by_name (struct Connection_List *p_cl, char *name);
+void cl_remove (struct Connection_List *p_cl, char *name);
+int cl_count (struct Connection_List *p_cl);
+void cl_check (struct Connection_List *p_cl);
 
 /*
 //void init_bookmarks (struct Bookmarks *bookmarks);
@@ -109,6 +112,8 @@ int search_directory (SConnection *pConn, gchar *item);
 void add_directory (SConnection *pConn, char *item);
 
 int connection_fill_from_string (struct Connection *p_conn, char *connection_string);
+
+void connection_copy (struct Connection *p_dst, struct Connection *p_src);
 
 #endif
 

--- a/src/grouptree.c
+++ b/src/grouptree.c
@@ -26,6 +26,7 @@
 #include "connection_list.h"
 #include "grouptree.h"
 #include "main.h"
+#include "utils.h"
 
 extern struct Connection_List conn_list;
 

--- a/src/gui.c
+++ b/src/gui.c
@@ -27,6 +27,7 @@
 #include <openssl/opensslv.h>
 #include <openssl/md5.h>
 #include <sys/utsname.h>
+#include <sys/wait.h>
 #include <string.h>
 #include <time.h>
 #include <stdlib.h>
@@ -403,8 +404,11 @@ struct EncodingEntry enc_array[] =
     { "EUC-JP (Japanese)", "EUC-JP" }
   };
 
+static gboolean search_entry_focus_out_event_cb (GtkWidget *, GdkEvent *,
+                                                 gpointer);
+
 void
-ifr_init ()
+ifr_init (void)
 {
   int i;
 
@@ -2289,7 +2293,7 @@ load_recent_connections ()
 }
 
 int
-save_recent_connections ()
+save_recent_connections (void)
 {
   struct Connection conn;
   struct Connection *p_conn;
@@ -4186,7 +4190,7 @@ search_entry_focus_in_event_cb (GtkWidget *widget, GdkEvent *event, gpointer use
   return (TRUE);
 }
 
-gboolean
+static gboolean
 search_entry_focus_out_event_cb (GtkWidget *widget, GdkEvent *event, gpointer user_data)
 {
   
@@ -4228,7 +4232,7 @@ create_accelerators ()
 }
 
 void 
-refresh_search_completion ()
+refresh_search_completion (void)
 {
   GtkListStore *model;
   GtkTreeIter iter; 
@@ -5667,7 +5671,7 @@ update_all_profiles ()
     }
 }
 
-int
+void
 open_connection (char *connection)
 {
   int rc;

--- a/src/gui.h
+++ b/src/gui.h
@@ -265,4 +265,18 @@ void sftp_download_files ();
 
 void sb_msg_push (char *);
 
+void refresh_search_completion (void);
+void connection_tab_add (struct ConnectionTab *connection_tab);
+void connection_tab_close (struct ConnectionTab *p_ct);
+void open_connection (char *connection);
+int save_recent_connections (void);
+
+void ifr_init (void);
+int ifr_get (struct Iteration_Function_Request *dest);
+
+struct Profile;
+void apply_profile_terminal (GtkWidget *terminal, struct Profile *p_profile);
+
+void start_gtk (int argc, char **argv);
+
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -218,7 +218,7 @@ lterm_iteration (void)
           break;
 
         case ITERATION_REFRESH_TREE_VIEW:
-          refresh_connection_tree_view ((struct GtkTreeView *) ifr_function.user_data);
+          refresh_connection_tree_view ((GtkTreeView *) ifr_function.user_data);
           break;
 
         case ITERATION_REFRESH_SFTP_PANEL:

--- a/src/main.c
+++ b/src/main.c
@@ -34,6 +34,8 @@
 #include <vte/vte.h>
 #include <libssh/libssh.h> 
 #include <libssh/callbacks.h>
+#include <X11/Xlib.h>
+#include <libintl.h>
 #include <pwd.h>
 #include "main.h"
 #include "gui.h"
@@ -45,6 +47,7 @@
 #include "utils.h"
 #include "config.h"
 #include "async.h"
+#include "terminal.h"
 
 #ifdef __APPLE__
 #include <sys/event.h>
@@ -193,7 +196,7 @@ gdk_threads_add_idle_full (G_PRIORITY_HIGH_IDLE,
 }
 
 void
-lterm_iteration ()
+lterm_iteration (void)
 {
   struct Iteration_Function_Request ifr_function;
   struct ConnectionTab *lterminal;

--- a/src/main.h
+++ b/src/main.h
@@ -183,5 +183,6 @@ int cmpver (char *v1, char *v2);
 
 //void recent_add (char *);
 
+void lterm_iteration (void);
 
 #endif

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -31,10 +31,14 @@ struct Protocol_List
     struct Protocol *tail;
   };
 
+void pl_init (struct Protocol_List *p_pl);
+void pl_release (struct Protocol_List *p_pl);
+
 struct Protocol *get_protocol (struct Protocol_List *p_pl, char *name);
 void manage_protocols (struct Protocol_List *);
 void refresh_protocols (struct Protocol_List *p_pl);
 int load_protocols_from_file_xml (char *filename, struct Protocol_List *p_pl);
 int save_protocols_to_file_xml (char *filename, struct Protocol_List *p_pl);
+void check_standard_protocols (struct Protocol_List *p_pl);
 
 #endif

--- a/src/sftp-panel.c
+++ b/src/sftp-panel.c
@@ -1514,7 +1514,7 @@ run_dialog:
             ////////////////////////////////
             lockSSH (__func__, TRUE);
 
-            rc = sftp_utimes (p_ssh_current->ssh_node->sftp, file_abs_path, &newFileTime);
+            rc = sftp_utimes (p_ssh_current->ssh_node->sftp, file_abs_path, newFileTime);
 
             lockSSH (__func__, FALSE);
             ////////////////////////////////

--- a/src/sftp-panel.c
+++ b/src/sftp-panel.c
@@ -68,7 +68,7 @@ GList *g_filetypes;
 char *transferStatusDesc[] = { "Ready", "In progress", "Paused", "Cancelled by user", "Cancelled for errors", "Completed", 0 };
 
 GtkWidget *transfer_window=NULL;
-GtkWidget *label_status;
+extern GtkWidget *label_status;
 GtkWidget *label_from;
 GtkWidget *label_to;
 GtkWidget *label_speed;
@@ -1638,7 +1638,7 @@ sftp_panel_order_invert ()
 }*/
 
 void
-refresh_panel_history ()
+refresh_panel_history (void)
 {
   struct Connection *c;
   struct Bookmark *b;

--- a/src/sftp-panel.h
+++ b/src/sftp-panel.h
@@ -172,6 +172,7 @@ int sftp_queue_length ();
 int sftp_queue_count (int *nUp, int *nDown);
 STransferInfo *sftp_queue_nth (int n);
 int sftp_queue_add (int action, GSList *filelist, struct SSH_Info *p_ssh, char *local_directory);
+void refresh_panel_history (void);
 
 #endif
 

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -34,6 +34,7 @@
 #include "ssh.h"
 #include "sftp-panel.h"
 #include "connection_list.h"
+#include "async.h"
 
 extern Globals globals;
 extern Prefs prefs;

--- a/src/transfer_window.c
+++ b/src/transfer_window.c
@@ -759,7 +759,7 @@ view_transfer_window ()
 
   // Scrolled window
   //GtkWindow *scrolled_window = gtk_scrolled_window_new (NULL, NULL);
-  GtkWindow *scrolled_window = GTK_WIDGET (gtk_builder_get_object (builder, "scrolled_window"));
+  GtkWindow *scrolled_window = GTK_WINDOW (gtk_builder_get_object (builder, "scrolled_window"));
   gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (scrolled_window), GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
   gtk_scrolled_window_set_shadow_type (GTK_SCROLLED_WINDOW (scrolled_window), GTK_SHADOW_ETCHED_IN);
   //transferAdjustment = gtk_scrolled_window_get_vadjustment (GTK_SCROLLED_WINDOW (scrolled_window));

--- a/src/transfer_window.c
+++ b/src/transfer_window.c
@@ -25,6 +25,8 @@
 #include "sftp-panel.h"
 #include "utils.h"
 #include "transfer_window.h"
+#include "async.h"
+#include "gui.h"
 
 extern GtkWidget *main_window;
 extern Globals globals;

--- a/src/utils.c
+++ b/src/utils.c
@@ -34,6 +34,7 @@
 #include <sys/dir.h>
 #include <sys/stat.h>
 #include <sys/utsname.h>
+#include <ctype.h>x
 
 #ifndef __APPLE__
 #include <crypt.h>

--- a/src/utils.h
+++ b/src/utils.h
@@ -46,5 +46,10 @@ char *shortenString (char *original, int threshold, char *shortened);
 int file_exists (char *filename);
 char *readFile (char *filename);
 
+int list_get_nth (char *list, int n, char sep, char *elem);
+void lower (char *s);
+void get_system (char *sys_name);
+int list_count (char *list, char sep);
+
 #endif
 

--- a/src/xml.c
+++ b/src/xml.c
@@ -647,7 +647,7 @@ xml_parse (char *doc, XML *p_xml)
   if (!g_markup_parse_context_parse (p_xml->context, doc, strlen (doc), NULL))
     {
       g_markup_parse_context_free (p_xml->context);
-      return;
+      return p_xml->error.code;
     }
 
   g_markup_parse_context_free (p_xml->context);


### PR DESCRIPTION
Future compilers are likely to reject implicit function declarations by default, so changes like these will be needed to avoid build failures.

Also avoid multiple definitions of label_status (to allow building with -fno-common, already a default in many compilers).

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
